### PR TITLE
WIP: Add account api

### DIFF
--- a/lib/twitter/client.rb
+++ b/lib/twitter/client.rb
@@ -5,7 +5,7 @@ require 'twitter/version'
 module Twitter
   class Client
     include Twitter::Utils
-    attr_accessor :access_token, :access_token_secret, :consumer_key, :consumer_secret, :proxy, :timeouts, :dev_environment
+    attr_accessor :access_token, :access_token_secret, :consumer_key, :consumer_secret, :proxy, :timeouts, :dev_environment, :enterprise_api
     attr_writer :user_agent
 
     # Initializes a new Client object

--- a/lib/twitter/rest/account_activity.rb
+++ b/lib/twitter/rest/account_activity.rb
@@ -11,6 +11,7 @@ module Twitter
       # Registers a webhook URL for all event types. The URL will be validated via CRC request before saving. In case the validation failed, returns comprehensive error message to the requester.
       # @see https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference
       # @see https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#post-account-activity-all-env-name-webhooks
+      # @see https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-enterprise#post-account-activity-all-env-name-webhooks
       # @note Create a webhook
       # @rate_limited Yes
       # @authentication Requires user context - all consumer and access tokens
@@ -18,36 +19,51 @@ module Twitter
       # @return [Hash]
       # @param env_name [String] Environment Name.
       # @param url [String] Encoded URL for the callback endpoint.
-      def create_webhook(env_name, url)
-        perform_request(:post, "/1.1/account_activity/all/#{env_name}/webhooks.json", url: url)
+      def create_webhook(url, env_name = nil)
+        if enterprise_api
+          perform_request(:post, "/1.1/account_activity/webhooks.json", url: url)
+        else
+          perform_request(:post, "/1.1/account_activity/all/#{env_name}/webhooks.json", url: url)
+        end
       end
 
       # Returns all environments, webhook URLs and their statuses for the authenticating app. Currently, only one webhook URL can be registered to each environment.
       # @see https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#get-account-activity-all-webhooks
+      # @see https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-enterprise#get-account-activity-all-webhooks
       # @note List webhooks
       # @rate_limited Yes
       # @authentication Requires user context - all consumer and access tokens
       # @raise [Twitter::Error::Unauthorized] Error raised when supplied user credentials are not valid.
       # @return [Hash]
       # @param env_name [String] Environment Name.
-      def list_webhooks(env_name)
-        perform_request(:get, "/1.1/account_activity/all/#{env_name}/webhooks.json")
+      def list_webhooks(env_name = nil)
+        if enterprise_api
+          perform_request(:get, "/1.1/account_activity/webhooks.json")
+        else
+          perform_request(:get, "/1.1/account_activity/all/#{env_name}/webhooks.json")
+        end
       end
 
       # Removes the webhook from the provided application's all activities configuration. The webhook ID can be accessed by making a call to GET /1.1/account_activity/all/webhooks.
       # @see https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#delete-account-activity-all-env-name-webhooks-webhook-id
+      # @see https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-enterprise#delete-account-activity-all-env-name-webhooks-webhook-id
       # @note Delete a webhook
       # @authentication Requires user context - all consumer and access tokens
       # @raise [Twitter::Error::Unauthorized] Error raised when supplied user credentials are not valid.
       # @return [nil]
       # @param env_name [String] Environment Name.
       # @param webhook_id [String] Webhook ID.
-      def delete_webhook(env_name, webhook_id)
-        perform_request(:delete, "/1.1/account_activity/all/#{env_name}/webhooks/#{webhook_id}.json")
+      def delete_webhook(webhook_id, env_name = nil)
+        if enterprise_api
+          perform_request(:delete, "/1.1/account_activity/webhooks/#{webhook_id}.json")
+        else
+          perform_request(:delete, "/1.1/account_activity/all/#{env_name}/webhooks/#{webhook_id}.json")
+        end
       end
 
       # Triggers the challenge response check (CRC) for the given enviroments webhook for all activites. If the check is successful, returns 204 and reenables the webhook by setting its status to valid.
       # @see https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#put-account-activity-all-env-name-webhooks-webhook-id
+      # @see https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-enterprise#put-account-activity-all-env-name-webhooks-webhook-id
       # @note Trigger CRC check to a webhook
       # @rate_limited Yes
       # @authentication Requires user context - all consumer and access tokens
@@ -55,44 +71,63 @@ module Twitter
       # @return [nil]
       # @param env_name [String] Environment Name.
       # @param webhook_id [String] Webhook ID.
-      def trigger_crc_check(env_name, webhook_id)
-        perform_request(:json_put, "/1.1/account_activity/all/#{env_name}/webhooks/#{webhook_id}.json")
+      def trigger_crc_check(webhook_id, env_name = nil)
+        if enterprise_api
+          perform_request(:json_put, "/1.1/account_activity/webhooks/#{webhook_id}.json")
+        else
+          perform_request(:json_put, "/1.1/account_activity/all/#{env_name}/webhooks/#{webhook_id}.json")
+        end
       end
 
       # Subscribes the provided application to all events for the provided environment for all message types. After activation, all events for the requesting user will be sent to the application's webhook via POST request.
       # @see https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#post-account-activity-all-env-name-subscriptions
+      # @see https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-enterprise#post-account-activity-all-env-name-subscriptions
       # @note Subscribe the user(whose credentials are provided) to the app so that the webhook can receive all types of events from user
       # @rate_limited Yes
       # @authentication Requires user context - all consumer and access tokens
       # @raise [Twitter::Error::Unauthorized] Error raised when supplied user credentials are not valid.
       # @return [nil]
-      # @param env_name [String] Environment Name
-      def create_subscription(env_name)
-        perform_request(:json_post, "/1.1/account_activity/all/#{env_name}/subscriptions.json")
+      # @param env_name_or_webhook_id [String] Environment Name or Webhook Id
+      def create_subscription(env_name_or_webhook_id)
+        if enterprise_api
+          perform_request(:json_post, "/1.1/account_activity/webhooks/#{env_name_or_webhook_id}/subscriptions/all.json")
+        else
+          perform_request(:json_post, "/1.1/account_activity/all/#{env_name_or_webhook_id}/subscriptions.json")
+        end
       end
 
       # Provides a way to determine if a webhook configuration is subscribed to the provided user's events. If the provided user context has an active subscription with provided application, returns 204 OK.
       # @see https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#get-account-activity-all-env-name-subscriptions
+      # @see https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-enterprise#get-account-activity-all-env-name-subscriptions
       # @note Check if the user is subscribed to the given app
       # @rate_limited Yes
       # @authentication Requires user context - all consumer and access tokens
       # @raise [Twitter::Error::Unauthorized] Error raised when supplied user credentials are not valid.
       # @return [nil]
-      # @param env_name [String] Environment Name
-      def check_subscription(env_name)
-        perform_request(:get, "/1.1/account_activity/all/#{env_name}/subscriptions.json")
+      # @param env_name_or_webhook_id [String] Environment Name or Webhook Id
+      def check_subscription(env_name_or_webhook_id)
+        if enterprise_api
+          perform_request(:get, "/1.1/account_activity/webhooks/#{env_name_or_webhook_id}/subscriptions/all.json")
+        else
+          perform_request(:get, "/1.1/account_activity/all/#{env_name_or_webhook_id}/subscriptions.json")
+        end
       end
 
       # Deactivates subscription(s) for the provided user context and application for all activities. After deactivation, all events for the requesting user will no longer be sent to the webhook URL.
       # @see https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-premium#delete-account-activity-all-env-name-subscriptions
+      # @see https://developer.twitter.com/en/docs/accounts-and-users/subscribe-account-activity/api-reference/aaa-enterprise#delete-account-activity-all-env-name-subscriptions
       # @note Deactivate a subscription, Users events will not be sent to the app
       # @rate_limited Yes
       # @authentication Requires user context - all consumer and access tokens
       # @raise [Twitter::Error::Unauthorized] Error raised when supplied user credentials are not valid.
       # @return [nil]
-      # @param env_name [String] Environment Name
-      def deactivate_subscription(env_name)
-        perform_request(:delete, "/1.1/account_activity/all/#{env_name}/subscriptions.json")
+      # @param env_name_or_webhook_id [String] Environment Name or Webhook Id
+      def deactivate_subscription(env_name_or_webhook_id)
+        if enterprise_api
+          perform_request(:delete, "/1.1/account_activity/webhooks/#{env_name_or_webhook_id}/subscriptions/all.json")
+        else
+          perform_request(:delete, "/1.1/account_activity/all/#{env_name_or_webhook_id}/subscriptions.json")
+        end
       end
     end
   end

--- a/lib/twitter/rest/account_activity.rb
+++ b/lib/twitter/rest/account_activity.rb
@@ -19,7 +19,7 @@ module Twitter
       # @param env_name [String] Environment Name.
       # @param url [String] Encoded URL for the callback endpoint.
       def create_webhook(env_name, url)
-        perform_request(:json_post, "/1.1/account_activity/all/#{env_name}/webhooks.json?url=#{url}")
+        perform_request(:post, "/1.1/account_activity/all/#{env_name}/webhooks.json", url: url)
       end
 
       # Returns all environments, webhook URLs and their statuses for the authenticating app. Currently, only one webhook URL can be registered to each environment.

--- a/spec/twitter/rest/account_activity_spec.rb
+++ b/spec/twitter/rest/account_activity_spec.rb
@@ -8,11 +8,11 @@ describe Twitter::REST::AccountActivity do
   describe '#create_webhook' do
     context 'with a webhook url passed' do
       before do
-        stub_post('/1.1/account_activity/all/env_name/webhooks.json?url=url').with(query: {url: 'url'}).to_return(body: fixture('account_activity_create_webhook.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        stub_post('/1.1/account_activity/all/env_name/webhooks.json').with(body: {url: 'url'}).to_return(body: fixture('account_activity_create_webhook.json'), headers: {content_type: 'application/json; charset=utf-8'})
       end
       it 'request create webhook' do
         @client.create_webhook('env_name', 'url')
-        expect(a_post('/1.1/account_activity/all/env_name/webhooks.json?url=url').with(body: {})).to have_been_made
+        expect(a_post('/1.1/account_activity/all/env_name/webhooks.json').with(body: {url: 'url'})).to have_been_made
       end
 
       it 'returns a webhook response' do

--- a/spec/twitter/rest/account_activity_spec.rb
+++ b/spec/twitter/rest/account_activity_spec.rb
@@ -5,125 +5,256 @@ describe Twitter::REST::AccountActivity do
     @client = Twitter::REST::Client.new(consumer_key: 'CK', consumer_secret: 'CS', access_token: 'AT', access_token_secret: 'AS')
   end
 
-  describe '#create_webhook' do
-    context 'with a webhook url passed' do
-      before do
-        stub_post('/1.1/account_activity/all/env_name/webhooks.json').with(body: {url: 'url'}).to_return(body: fixture('account_activity_create_webhook.json'), headers: {content_type: 'application/json; charset=utf-8'})
-      end
-      it 'request create webhook' do
-        @client.create_webhook('env_name', 'url')
-        expect(a_post('/1.1/account_activity/all/env_name/webhooks.json').with(body: {url: 'url'})).to have_been_made
-      end
+  context 'with enterpise API' do
+    before do
+      @client.enterprise_api = true
+    end
 
-      it 'returns a webhook response' do
-        response = @client.create_webhook('env_name', 'url')
-        expect(response).to be_a Hash
-        expect(response[:id]).to eq('1234567890')
+    describe '#create_webhook' do
+      context 'with a webhook url passed' do
+        before do
+          stub_post('/1.1/account_activity/webhooks.json').with(body: {url: 'url'}).to_return(body: fixture('account_activity_create_webhook.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        end
+        it 'request create webhook' do
+          @client.create_webhook('url')
+          expect(a_post('/1.1/account_activity/webhooks.json').with(body: {url: 'url'})).to have_been_made
+        end
+
+        it 'returns a webhook response' do
+          response = @client.create_webhook('url')
+          expect(response).to be_a Hash
+          expect(response[:id]).to eq('1234567890')
+        end
+      end
+    end
+
+    describe '#list_webhooks' do
+      context 'list webhooks' do
+        before do
+          stub_get('/1.1/account_activity/webhooks.json').to_return(body: fixture('account_activity_list_webhook.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        end
+        it 'request list webhooks' do
+          @client.list_webhooks('env_name')
+          expect(a_get('/1.1/account_activity/webhooks.json').with(body: {})).to have_been_made
+        end
+
+        it 'returns a webhook response' do
+          response = @client.list_webhooks('env_name')
+          expect(response).to be_a Hash
+          expect(response[:environments]).to be_a Array
+          expect(response[:environments][0][:webhooks]).to be_a Array
+          expect(response[:environments][0][:webhooks][0][:id]).to eq('1234567890')
+        end
+      end
+    end
+
+    describe '#trigger_crc_check' do
+      context 'trigger crc check' do
+        before do
+          stub_put('/1.1/account_activity/webhooks/1234567890.json').to_return(status: 204, headers: {content_type: 'application/json; charset=utf-8'})
+        end
+        it 'request crc check' do
+          @client.trigger_crc_check('1234567890')
+          expect(a_put('/1.1/account_activity/webhooks/1234567890.json').with(body: {})).to have_been_made
+        end
+
+        it 'returns a webhook response' do
+          response = @client.trigger_crc_check('1234567890')
+          expect(response).to eq('')
+        end
+      end
+    end
+
+    describe '#create_subscription' do
+      context 'create subscription' do
+        before do
+          stub_post('/1.1/account_activity/webhooks/1234567890/subscriptions/all.json').to_return(status: 204, headers: {content_type: 'application/json; charset=utf-8'})
+        end
+        it 'request create subscription' do
+          @client.create_subscription('1234567890')
+          expect(a_post('/1.1/account_activity/webhooks/1234567890/subscriptions/all.json').with(body: {})).to have_been_made
+        end
+
+        it 'returns a webhook response' do
+          response = @client.create_subscription('1234567890')
+          expect(response).to eq('')
+        end
+      end
+    end
+
+    describe '#check_subscription' do
+      context 'check subscription' do
+        before do
+          stub_get('/1.1/account_activity/webhooks/1234567890/subscriptions/all.json').to_return(status: 204, headers: {content_type: 'application/json; charset=utf-8'})
+        end
+        it 'request check subscription' do
+          @client.check_subscription('1234567890')
+          expect(a_get('/1.1/account_activity/webhooks/1234567890/subscriptions/all.json').with(body: {})).to have_been_made
+        end
+
+        it 'returns a webhook response' do
+          response = @client.check_subscription('1234567890')
+          expect(response).to eq('')
+        end
+      end
+    end
+
+    describe '#delete_webhook' do
+      context 'delete webhook' do
+        before do
+          stub_delete('/1.1/account_activity/webhooks/1234567890.json').to_return(status: 204, headers: {content_type: 'application/json; charset=utf-8'})
+        end
+        it 'request delete webhook' do
+          @client.delete_webhook('1234567890')
+          expect(a_delete('/1.1/account_activity/webhooks/1234567890.json').with(body: {})).to have_been_made
+        end
+
+        it 'returns a webhook response' do
+          response = @client.delete_webhook('1234567890')
+          expect(response).to eq('')
+        end
+      end
+    end
+
+    describe '#deactivate_subscription' do
+      context 'deactivate subscription' do
+        before do
+          stub_delete('/1.1/account_activity/webhooks/1234567890/subscriptions/all.json').to_return(status: 204, headers: {content_type: 'application/json; charset=utf-8'})
+        end
+        it 'request deactivate subscription' do
+          @client.deactivate_subscription('1234567890')
+          expect(a_delete('/1.1/account_activity/webhooks/1234567890/subscriptions/all.json').with(body: {})).to have_been_made
+        end
+
+        it 'returns a webhook response' do
+          response = @client.deactivate_subscription('1234567890')
+          expect(response).to eq('')
+        end
       end
     end
   end
 
-  describe '#list_webhooks' do
-    context 'list webhooks' do
-      before do
-        stub_get('/1.1/account_activity/all/env_name/webhooks.json').to_return(body: fixture('account_activity_list_webhook.json'), headers: {content_type: 'application/json; charset=utf-8'})
-      end
-      it 'request list webhooks' do
-        @client.list_webhooks('env_name')
-        expect(a_get('/1.1/account_activity/all/env_name/webhooks.json').with(body: {})).to have_been_made
-      end
+  context 'without enterpise API' do
+    describe '#create_webhook' do
+      context 'with a webhook url passed' do
+        before do
+          stub_post('/1.1/account_activity/all/env_name/webhooks.json').with(body: {url: 'url'}).to_return(body: fixture('account_activity_create_webhook.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        end
+        it 'request create webhook' do
+          @client.create_webhook('url', 'env_name')
+          expect(a_post('/1.1/account_activity/all/env_name/webhooks.json').with(body: {url: 'url'})).to have_been_made
+        end
 
-      it 'returns a webhook response' do
-        response = @client.list_webhooks('env_name')
-        expect(response).to be_a Hash
-        expect(response[:environments]).to be_a Array
-        expect(response[:environments][0][:webhooks]).to be_a Array
-        expect(response[:environments][0][:webhooks][0][:id]).to eq('1234567890')
+        it 'returns a webhook response' do
+          response = @client.create_webhook('url', 'env_name')
+          expect(response).to be_a Hash
+          expect(response[:id]).to eq('1234567890')
+        end
       end
     end
-  end
 
-  describe '#trigger_crc_check' do
-    context 'trigger crc check' do
-      before do
-        stub_put('/1.1/account_activity/all/env_name/webhooks/1234567890.json').to_return(status: 204, headers: {content_type: 'application/json; charset=utf-8'})
-      end
-      it 'request crc check' do
-        @client.trigger_crc_check('env_name', '1234567890')
-        expect(a_put('/1.1/account_activity/all/env_name/webhooks/1234567890.json').with(body: {})).to have_been_made
-      end
+    describe '#list_webhooks' do
+      context 'list webhooks' do
+        before do
+          stub_get('/1.1/account_activity/all/env_name/webhooks.json').to_return(body: fixture('account_activity_list_webhook.json'), headers: {content_type: 'application/json; charset=utf-8'})
+        end
+        it 'request list webhooks' do
+          @client.list_webhooks('env_name')
+          expect(a_get('/1.1/account_activity/all/env_name/webhooks.json').with(body: {})).to have_been_made
+        end
 
-      it 'returns a webhook response' do
-        response = @client.trigger_crc_check('env_name', '1234567890')
-        expect(response).to eq('')
+        it 'returns a webhook response' do
+          response = @client.list_webhooks('env_name')
+          expect(response).to be_a Hash
+          expect(response[:environments]).to be_a Array
+          expect(response[:environments][0][:webhooks]).to be_a Array
+          expect(response[:environments][0][:webhooks][0][:id]).to eq('1234567890')
+        end
       end
     end
-  end
 
-  describe '#create_subscription' do
-    context 'create subscription' do
-      before do
-        stub_post('/1.1/account_activity/all/env_name/subscriptions.json').to_return(status: 204, headers: {content_type: 'application/json; charset=utf-8'})
-      end
-      it 'request create subscription' do
-        @client.create_subscription('env_name')
-        expect(a_post('/1.1/account_activity/all/env_name/subscriptions.json').with(body: {})).to have_been_made
-      end
+    describe '#trigger_crc_check' do
+      context 'trigger crc check' do
+        before do
+          stub_put('/1.1/account_activity/all/env_name/webhooks/1234567890.json').to_return(status: 204, headers: {content_type: 'application/json; charset=utf-8'})
+        end
+        it 'request crc check' do
+          @client.trigger_crc_check('1234567890', 'env_name')
+          expect(a_put('/1.1/account_activity/all/env_name/webhooks/1234567890.json').with(body: {})).to have_been_made
+        end
 
-      it 'returns a webhook response' do
-        response = @client.create_subscription('env_name')
-        expect(response).to eq('')
+        it 'returns a webhook response' do
+          response = @client.trigger_crc_check('1234567890', 'env_name')
+          expect(response).to eq('')
+        end
       end
     end
-  end
 
-  describe '#check_subscription' do
-    context 'check subscription' do
-      before do
-        stub_get('/1.1/account_activity/all/env_name/subscriptions.json').to_return(status: 204, headers: {content_type: 'application/json; charset=utf-8'})
-      end
-      it 'request check subscription' do
-        @client.check_subscription('env_name')
-        expect(a_get('/1.1/account_activity/all/env_name/subscriptions.json').with(body: {})).to have_been_made
-      end
+    describe '#create_subscription' do
+      context 'create subscription' do
+        before do
+          stub_post('/1.1/account_activity/all/env_name/subscriptions.json').to_return(status: 204, headers: {content_type: 'application/json; charset=utf-8'})
+        end
+        it 'request create subscription' do
+          @client.create_subscription('env_name')
+          expect(a_post('/1.1/account_activity/all/env_name/subscriptions.json').with(body: {})).to have_been_made
+        end
 
-      it 'returns a webhook response' do
-        response = @client.check_subscription('env_name')
-        expect(response).to eq('')
+        it 'returns a webhook response' do
+          response = @client.create_subscription('env_name')
+          expect(response).to eq('')
+        end
       end
     end
-  end
 
-  describe '#delete_webhook' do
-    context 'delete webhook' do
-      before do
-        stub_delete('/1.1/account_activity/all/env_name/webhooks/1234567890.json').to_return(status: 204, headers: {content_type: 'application/json; charset=utf-8'})
-      end
-      it 'request delete webhook' do
-        @client.delete_webhook('env_name', '1234567890')
-        expect(a_delete('/1.1/account_activity/all/env_name/webhooks/1234567890.json').with(body: {})).to have_been_made
-      end
+    describe '#check_subscription' do
+      context 'check subscription' do
+        before do
+          stub_get('/1.1/account_activity/all/env_name/subscriptions.json').to_return(status: 204, headers: {content_type: 'application/json; charset=utf-8'})
+        end
+        it 'request check subscription' do
+          @client.check_subscription('env_name')
+          expect(a_get('/1.1/account_activity/all/env_name/subscriptions.json').with(body: {})).to have_been_made
+        end
 
-      it 'returns a webhook response' do
-        response = @client.delete_webhook('env_name', '1234567890')
-        expect(response).to eq('')
+        it 'returns a webhook response' do
+          response = @client.check_subscription('env_name')
+          expect(response).to eq('')
+        end
       end
     end
-  end
 
-  describe '#deactivate_subscription' do
-    context 'deactivate subscription' do
-      before do
-        stub_delete('/1.1/account_activity/all/env_name/subscriptions.json').to_return(status: 204, headers: {content_type: 'application/json; charset=utf-8'})
-      end
-      it 'request deactivate subscription' do
-        @client.deactivate_subscription('env_name')
-        expect(a_delete('/1.1/account_activity/all/env_name/subscriptions.json').with(body: {})).to have_been_made
-      end
+    describe '#delete_webhook' do
+      context 'delete webhook' do
+        before do
+          stub_delete('/1.1/account_activity/all/env_name/webhooks/1234567890.json').to_return(status: 204, headers: {content_type: 'application/json; charset=utf-8'})
+        end
+        it 'request delete webhook' do
+          @client.delete_webhook('1234567890', 'env_name')
+          expect(a_delete('/1.1/account_activity/all/env_name/webhooks/1234567890.json').with(body: {})).to have_been_made
+        end
 
-      it 'returns a webhook response' do
-        response = @client.deactivate_subscription('env_name')
-        expect(response).to eq('')
+        it 'returns a webhook response' do
+          response = @client.delete_webhook('1234567890', 'env_name')
+          expect(response).to eq('')
+        end
+      end
+    end
+
+    describe '#deactivate_subscription' do
+      context 'deactivate subscription' do
+        before do
+          stub_delete('/1.1/account_activity/all/env_name/subscriptions.json').to_return(status: 204, headers: {content_type: 'application/json; charset=utf-8'})
+        end
+        it 'request deactivate subscription' do
+          @client.deactivate_subscription('env_name')
+          expect(a_delete('/1.1/account_activity/all/env_name/subscriptions.json').with(body: {})).to have_been_made
+        end
+
+        it 'returns a webhook response' do
+          response = @client.deactivate_subscription('env_name')
+          expect(response).to eq('')
+        end
       end
     end
   end


### PR DESCRIPTION
This has to be merged after : https://github.com/FabienChaynes/twitter/pull/1

I may have to change url in `Twitter::Rest::AccountActivity` to support twitter enterprise, `/1.1/account_activity/all/#{env_name}/webhooks.json` becomes `/1.1/account_activity/webhooks.json` but I'm not sure if this is mandatory or not. I keep this MR in WIP until I test this point.

The only change is for `Twitter::Rest::AccountActivity#create_webhook` at the moment.